### PR TITLE
Feat/admin/job

### DIFF
--- a/src/apis/townApi.js
+++ b/src/apis/townApi.js
@@ -53,13 +53,21 @@ export const createQuest = async (requestDTO) => {
   return response.data;
 };
 
-export const fetchQuestStatusList = async () => {
-  const response = await axiosInstance.get(`/town/quest/status`);
+export const fetchQuestStatusList = async (page = 1, size = 10) => {
+  const response = await axiosInstance.get(`/town/quest/status`, {
+    params: { page, size },
+  });
   return response.data;
 };
 
-export const fetchMemberQuestRequests = async (questId) => {
-  const response = await axiosInstance.get(`/town/quest/requests/${questId}`);
+export const fetchMemberQuestRequests = async (
+  questId,
+  page = 1,
+  size = 10
+) => {
+  const response = await axiosInstance.get(`/town/quest/requests/${questId}`, {
+    params: { page, size },
+  });
   return response.data;
 };
 
@@ -94,7 +102,9 @@ export const completeWishItem = async (memberWishId) => {
   return response.data;
 };
 
-export const fetchMemberWishRequests = async () => {
-  const response = await axiosInstance.get(`/town/wish/requests`);
+export const fetchMemberWishRequests = async (page = 1, size = 10) => {
+  const response = await axiosInstance.get(`/town/wish/requests`, {
+    params: { page, size },
+  });
   return response.data;
 };

--- a/src/apis/townApi.js
+++ b/src/apis/townApi.js
@@ -32,11 +32,11 @@ export const fetchJobRequests = async () => {
   return response.data;
 };
 
-export const createJob = async (jobData) => {
+export const createJob = async ({ name, description, pay }) => {
   const response = await axiosInstance.post(`/town/job/create`, {
-    name: jobData.name,
-    description: jobData.description,
-    pay: jobData.pay,
+    name,
+    description,
+    pay,
   });
   return response.data;
 };

--- a/src/apis/townApi.js
+++ b/src/apis/townApi.js
@@ -27,8 +27,10 @@ export const fetchTax = async () => {
   return response.data;
 };
 
-export const fetchJobRequests = async () => {
-  const response = await axiosInstance.get(`/town/job/requests`);
+export const fetchJobRequests = async (page = 1, size = 10) => {
+  const response = await axiosInstance.get(`/town/job/requests`, {
+    params: { page, size },
+  });
   return response.data;
 };
 

--- a/src/components/AdminTable/index.jsx
+++ b/src/components/AdminTable/index.jsx
@@ -10,6 +10,8 @@ import {
   EmptyWrapper,
   EmptyMsg,
   ActionButton,
+  PaginationWrapper,
+  PageButton,
 } from './styled';
 
 /**
@@ -25,7 +27,30 @@ import {
  * </pre>
  */
 
-const AdminTable = ({ headers, data, emptyMessage }) => {
+const AdminTable = ({
+  headers,
+  data,
+  emptyMessage,
+  currentPage,
+  totalPages,
+  onPageChange,
+}) => {
+  const renderPageButtons = () => {
+    const buttons = [];
+    for (let i = 1; i <= totalPages; i++) {
+      buttons.push(
+        <PageButton
+          key={i}
+          onClick={() => onPageChange(i)}
+          active={i === currentPage}
+        >
+          {i}
+        </PageButton>
+      );
+    }
+    return buttons;
+  };
+
   return (
     <Container>
       {data.length > 0 ? (
@@ -61,6 +86,7 @@ const AdminTable = ({ headers, data, emptyMessage }) => {
               ))}
             </Tbody>
           </Table>
+          <PaginationWrapper>{renderPageButtons()}</PaginationWrapper>
         </TableWrapper>
       ) : (
         <EmptyWrapper>
@@ -69,12 +95,6 @@ const AdminTable = ({ headers, data, emptyMessage }) => {
       )}
     </Container>
   );
-};
-
-AdminTable.propTypes = {
-  headers: PropTypes.arrayOf(PropTypes.string).isRequired,
-  data: PropTypes.arrayOf(PropTypes.object).isRequired,
-  emptyMessage: PropTypes.string,
 };
 
 export default AdminTable;

--- a/src/components/AdminTable/styled.js
+++ b/src/components/AdminTable/styled.js
@@ -75,3 +75,25 @@ export const ActionButton = styled.button`
     background-color: ${colors.gray};
   }
 `;
+
+export const PaginationWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 3vh;
+`;
+
+export const PageButton = styled.button`
+  background-color: transparent;
+  color: ${({ active }) => (active ? 'black' : `${colors.dark_gray}`)};
+  border: none;
+  padding: 1vh 0vw;
+  margin: 0 0.5vw;
+  font-size: 1rem;
+  cursor: pointer;
+  font-weight: ${({ active }) => (active ? 'bold' : 'normal')};
+  text-decoration: ${({ active }) => (active ? 'underline' : 'none')};
+
+  &:hover {
+    color: black;
+  }
+`;

--- a/src/components/CreateJobModal/index.jsx
+++ b/src/components/CreateJobModal/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button } from '../index';
 import useDebouncedState from '../../hooks/useDebouncedState';
 import {
@@ -55,13 +55,11 @@ const CreateJobModal = ({ isOpen, onClose, onCreate }) => {
         <ModalContent>
           <Label>역할 이름</Label>
           <Input
-            value={name}
             onChange={(e) => debouncedSetName(e.target.value)}
             placeholder='역할의 이름을 입력하세요'
           />
           <Label>설명</Label>
           <Input
-            value={description}
             onChange={(e) => debouncedSetDescription(e.target.value)}
             placeholder='설명을 입력하세요'
           />
@@ -70,7 +68,6 @@ const CreateJobModal = ({ isOpen, onClose, onCreate }) => {
             <MoaImage src={moaIcon} alt='Moa Icon' />
             <PayInput
               type='number'
-              value={pay}
               onChange={(e) => debouncedSetPay(Number(e.target.value))}
               min='0'
               placeholder='급여를 입력하세요'

--- a/src/components/JobStatus/index.jsx
+++ b/src/components/JobStatus/index.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useQuery } from 'react-query';
 import { fetchJobRequests } from '../../apis/townApi';
-import { StatusTable } from '../index';
+import { StatusTable, Loading } from '../index';
 
 /**
  * 역할 현황 컴포넌트
@@ -17,7 +17,13 @@ import { StatusTable } from '../index';
  */
 
 const JobStatus = () => {
-  const { data: jobrequests = [] } = useQuery('jobrequests', fetchJobRequests);
+  const [page, setPage] = useState(1);
+  const [size, setSize] = useState(4);
+  const { data, isLoading } = useQuery(['jobRequests', page, size], () =>
+    fetchJobRequests(page, size)
+  );
+
+  const jobrequests = data?.content || [];
 
   const headers = ['No', '역할', '신청인'];
   const tableData = jobrequests.map((jobrequest, index) => ({
@@ -26,12 +32,17 @@ const JobStatus = () => {
     nickName: jobrequest.nickName,
   }));
 
+  if (isLoading) {
+    return <Loading text='데이터를 불러오는 중...' />;
+  }
+
   return (
     <StatusTable
       title='역할 신청 현황'
       headers={headers}
       data={tableData}
       emptyMessage='역할 신청 내역이 없습니다.'
+      goto='/admin/job-request'
     />
   );
 };

--- a/src/components/QuestStatus/index.jsx
+++ b/src/components/QuestStatus/index.jsx
@@ -35,6 +35,7 @@ const QuestStatus = () => {
       headers={headers}
       data={tableData}
       emptyMessage='퀘스트 수행 내역이 없습니다.'
+      goto=''
     />
   );
 };

--- a/src/components/QuestStatus/index.jsx
+++ b/src/components/QuestStatus/index.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useQuery } from 'react-query';
 import { fetchQuestStatusList } from '../../apis/townApi';
-import { StatusTable } from '../index';
+import { StatusTable, Loading } from '../index';
 
 /**
  * 퀘스트 현황 컴포넌트
@@ -17,10 +17,13 @@ import { StatusTable } from '../index';
  */
 
 const QuestStatus = () => {
-  const { data: questStatus = [] } = useQuery(
-    'questStatus',
-    fetchQuestStatusList
+  const [page, setPage] = useState(1);
+  const [size, setSize] = useState(4);
+  const { data, isLoading } = useQuery(['questStatus', page, size], () =>
+    fetchQuestStatusList(page, size)
   );
+
+  const questStatus = data?.content || [];
 
   const headers = ['No', '퀘스트', '선정 현황'];
   const tableData = questStatus.map((quest, index) => ({
@@ -29,13 +32,17 @@ const QuestStatus = () => {
     status: `${quest.selectedCnt}/${quest.capacity}`,
   }));
 
+  if (isLoading) {
+    return <Loading text='데이터를 불러오는 중...' />;
+  }
+
   return (
     <StatusTable
       title='퀘스트 수행 현황'
       headers={headers}
       data={tableData}
       emptyMessage='퀘스트 수행 내역이 없습니다.'
-      goto=''
+      goto='/admin/quest'
     />
   );
 };

--- a/src/components/StatusTable/index.jsx
+++ b/src/components/StatusTable/index.jsx
@@ -11,8 +11,12 @@ import {
   EmptyMsg,
   EmptyImg,
   EmptyWrapper,
+  MoreIcon,
+  TitleWrapper,
 } from './styled';
 import empty from '../../assets/images/empty.png';
+import more from '../../assets/images/circle_right.svg';
+import { Link } from 'react-router-dom';
 
 /**
  * 현황 테이블 컴포넌트
@@ -27,10 +31,16 @@ import empty from '../../assets/images/empty.png';
  * </pre>
  */
 
-const StatusTable = ({ title, headers, data, emptyMessage }) => {
+const StatusTable = ({ title, headers, data, emptyMessage, goto }) => {
   return (
     <Container>
-      <Title>{title}</Title>
+      <TitleWrapper>
+        <Title>{title}</Title>
+        <Link to={goto}>
+          <MoreIcon src={more} />
+        </Link>
+      </TitleWrapper>
+
       {data.length === 0 ? (
         <EmptyWrapper>
           <EmptyImg src={empty} />

--- a/src/components/StatusTable/styled.js
+++ b/src/components/StatusTable/styled.js
@@ -16,7 +16,6 @@ export const Title = styled.div`
   font-size: 1.4rem;
   text-align: center;
   font-weight: bold;
-  margin-top: 2vw;
 `;
 
 export const TableWrapper = styled.div`
@@ -107,4 +106,20 @@ export const EmptyImg = styled.img`
   width: 8vw;
   height: auto;
   margin-top: 4vh;
+`;
+
+export const MoreIcon = styled.img`
+  width: 2dvw;
+  height: auto;
+  cursor: pointer;
+`;
+
+export const TitleWrapper = styled.div`
+  width: 80%;
+  height: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 3vh;
+  gap: 1vw;
 `;

--- a/src/components/WishStatus/index.jsx
+++ b/src/components/WishStatus/index.jsx
@@ -37,6 +37,7 @@ const WishStatus = () => {
       headers={headers}
       data={tableData}
       emptyMessage='위시 요청 내역이 없습니다.'
+      goto=''
     />
   );
 };

--- a/src/components/WishStatus/index.jsx
+++ b/src/components/WishStatus/index.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useQuery } from 'react-query';
 import { fetchMemberWishRequests } from '../../apis/townApi';
-import { StatusTable } from '../index';
+import { StatusTable, Loading } from '../index';
 
 /**
  * 위시 상품 현황 컴포넌트
@@ -17,19 +17,24 @@ import { StatusTable } from '../index';
  */
 
 const WishStatus = () => {
-  const { data: wishRequests = [] } = useQuery(
-    'wishRequests',
-    fetchMemberWishRequests
+  const [page, setPage] = useState(1);
+  const [size, setSize] = useState(4);
+  const { data, isLoading } = useQuery(['wishRequests', page, size], () =>
+    fetchMemberWishRequests(page, size)
   );
 
+  const wishRequests = data?.content || [];
+
   const headers = ['No', '위시 상품', '신청인'];
-  const tableData = wishRequests
-    ? wishRequests.map((wishRequest, index) => ({
-        no: index + 1,
-        name: wishRequest.wishName,
-        nickName: wishRequest.nickName,
-      }))
-    : [];
+  const tableData = wishRequests.map((wishRequest, index) => ({
+    no: index + 1,
+    name: wishRequest.wishName,
+    nickName: wishRequest.nickName,
+  }));
+
+  if (isLoading) {
+    return <Loading text='데이터를 불러오는 중...' />;
+  }
 
   return (
     <StatusTable
@@ -37,7 +42,7 @@ const WishStatus = () => {
       headers={headers}
       data={tableData}
       emptyMessage='위시 요청 내역이 없습니다.'
-      goto=''
+      goto='/admin/wish-request'
     />
   );
 };

--- a/src/pages/AdminJob/index.jsx
+++ b/src/pages/AdminJob/index.jsx
@@ -1,61 +1,3 @@
-// import React from 'react';
-// import { useQuery } from 'react-query';
-// import { fetchTownInfo } from '../../apis/memberApi';
-// import { getJobsByTownId } from '../../apis/jobApi';
-// import {
-//   AdminHeader,
-//   AdminNav,
-//   AdminTable,
-//   CreateHeader,
-// } from '../../components';
-// import { Container, ContentWrapper, BodyWrapper, Title } from './styled';
-
-// /**
-//  * 관리자 역할 관리 페이지
-//  * @author 임원정
-//  * @since 2024.09.03
-//  * @version 1.0
-//  *
-//  * <pre>
-//  * 수정일        수정자        수정내용
-//  * ----------  --------    ---------------------------
-//  * 2024.09.03 	임원정        최초 생성
-//  * </pre>
-//  */
-
-// const AdminJob = () => {
-//   const { data: townInfo = {} } = useQuery('townInfo', fetchTownInfo);
-//   const { data: job = [] } = useQuery('job', getJobsByTownId);
-
-//   const headers = ['No', '역할', '설명', '급여'];
-//   const tableData = job.map((job, index) => ({
-//     no: { type: 'text', value: index + 1 },
-//     name: { type: 'text', value: job.name },
-//     description: { type: 'text', value: job.description },
-//     pay: { type: 'text', value: job.pay + ' 모아' },
-//   }));
-
-//   return (
-//     <Container>
-//       <AdminHeader />
-//       <BodyWrapper>
-//         <AdminNav townInfo={townInfo} />
-//         <ContentWrapper>
-//           <Title>역할 관리</Title>
-//           <CreateHeader title='역할 목록' />
-//           <AdminTable
-//             headers={headers}
-//             data={tableData}
-//             emptyMessage='역할이 없습니다.'
-//           />
-//         </ContentWrapper>
-//       </BodyWrapper>
-//     </Container>
-//   );
-// };
-
-// export default AdminJob;
-
 import React, { useState } from 'react';
 import { useQuery, useMutation } from 'react-query';
 import { getJobsByTownId } from '../../apis/jobApi';
@@ -64,6 +6,19 @@ import AdminLayout from '../../layouts/AdminLayout';
 import { AdminTable, CreateHeader } from '../../components';
 import { ContentWrapper, Title } from './styled';
 import CreateJobModal from '../../components/CreateJobModal';
+
+/**
+ * 관리자 역할 관리 페이지
+ * @author 임원정
+ * @since 2024.09.03
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.03 	임원정        최초 생성
+ * </pre>
+ */
 
 const AdminJob = () => {
   const { data: job = [], refetch } = useQuery('job', getJobsByTownId);
@@ -87,8 +42,8 @@ const AdminJob = () => {
     },
   });
 
-  const handleCreate = (jobData) => {
-    mutation.mutate(jobData);
+  const handleCreate = ({ name, description, pay }) => {
+    mutation.mutate({ name, description, pay });
   };
 
   return (

--- a/src/pages/AdminJob/index.jsx
+++ b/src/pages/AdminJob/index.jsx
@@ -21,6 +21,8 @@ import CreateJobModal from '../../components/CreateJobModal';
  */
 
 const AdminJob = () => {
+  const [page, setPage] = useState(1);
+  const [size, setSize] = useState(4);
   const { data: job = [], refetch } = useQuery('job', getJobsByTownId);
   const [isModalOpen, setIsModalOpen] = useState(false);
 

--- a/src/pages/AdminJob/styled.js
+++ b/src/pages/AdminJob/styled.js
@@ -1,26 +1,4 @@
 import styled from 'styled-components';
-import { colors } from '../../styles/colors';
-
-// export const Container = styled.div`
-//   width: 100vw;
-//   height: 100vh;
-//   background: ${colors.background_gray};
-//   display: flex;
-//   flex-direction: column;
-//   align-items: center;
-//   justify-content: flex-start;
-//   padding: 3vh 4vw 4vh;
-//   box-sizing: border-box;
-// `;
-
-// export const BodyWrapper = styled.div`
-//   width: 100%;
-//   height: 100%;
-//   display: flex;
-//   align-items: center;
-//   justify-content: space-between;
-//   padding-top: 2vw;
-// `;
 
 export const ContentWrapper = styled.div`
   width: 80%;

--- a/src/pages/AdminJobRequest/index.jsx
+++ b/src/pages/AdminJobRequest/index.jsx
@@ -1,189 +1,22 @@
-// // import React, { useState } from 'react';
-// // import { useQuery, useMutation } from 'react-query';
-// // import { fetchTownInfo } from '../../apis/memberApi';
-// // import { fetchJobRequests, allowJobRequest } from '../../apis/townApi';
-// // import {
-// //   AdminHeader,
-// //   AdminNav,
-// //   AdminTable,
-// //   AdminModal,
-// // } from '../../components';
-// // import { Container, ContentWrapper, Wrapper, Title } from './styled';
-// // import { colors } from '../../styles/colors';
-
-// // /**
-// //  * 관리자 역할 신청 내역 페이지
-// //  * @author 임원정
-// //  * @since 2024.09.03
-// //  * @version 1.0
-// //  *
-// //  * <pre>
-// //  * 수정일        수정자        수정내용
-// //  * ----------  --------    ---------------------------
-// //  * 2024.09.03 	임원정        최초 생성
-// //  * </pre>
-// //  */
-
-// // const AdminJobRequest = () => {
-// //   const { data: townInfo = {} } = useQuery('townInfo', fetchTownInfo);
-// //   const { data: jobrequests = [], refetch } = useQuery(
-// //     'jobrequests',
-// //     fetchJobRequests
-// //   );
-
-// //   const [isModalOpen, setIsModalOpen] = useState(false);
-// //   const [selectedJobRequestId, setSelectedJobRequestId] = useState(null);
-
-// //   const headers = ['No', '역할', '코멘트', '신청인', '승인 여부'];
-// //   const tableData = jobrequests.map((jobrequest, index) => ({
-// //     no: { type: 'text', value: index + 1 },
-// //     name: { type: 'text', value: jobrequest.name },
-// //     comments: { type: 'text', value: jobrequest.comments },
-// //     nickName: { type: 'text', value: jobrequest.nickName },
-// //     allowYN: {
-// //       type: jobrequest.allowYN === 'Y' ? 'text' : 'button',
-// //       value: jobrequest.allowYN === 'Y' ? '승인 완료' : '승인',
-// //       color:
-// //         jobrequest.allowYN === 'Y' ? 'transparent' : `${colors.table_orange}`,
-// //       onClick: () => {
-// //         setSelectedJobRequestId(jobrequest.jobRequestId);
-// //         setIsModalOpen(true);
-// //       },
-// //     },
-// //   }));
-
-// //   const mutation = useMutation(allowJobRequest, {
-// //     onSuccess: () => {
-// //       refetch();
-// //       setIsModalOpen(false);
-// //     },
-// //     onError: (error) => {
-// //       console.error('승인 실패:', error);
-// //     },
-// //   });
-
-// //   const handleConfirm = () => {
-// //     if (selectedJobRequestId) {
-// //       mutation.mutate(selectedJobRequestId);
-// //     }
-// //   };
-
-// //   const handleCancel = () => {
-// //     setIsModalOpen(false);
-// //   };
-
-// //   return (
-// //     <Container>
-// //       <AdminHeader />
-// //       <Wrapper>
-// //         <AdminNav townInfo={townInfo} />
-// //         <ContentWrapper>
-// //           <Title>역할 신청 내역</Title>
-// //           <AdminTable
-// //             headers={headers}
-// //             data={tableData}
-// //             emptyMessage='역할 신청 내역이 없습니다.'
-// //           />
-// //         </ContentWrapper>
-// //       </Wrapper>
-// //       {isModalOpen && (
-// //         <AdminModal
-// //           isOpen={isModalOpen}
-// //           onConfirm={handleConfirm}
-// //           onCancel={handleCancel}
-// //           title='승인하시겠습니까?'
-// //         />
-// //       )}
-// //     </Container>
-// //   );
-// // };
-
-// // export default AdminJobRequest;
-
-// import React, { useState } from 'react';
-// import { useQuery, useMutation } from 'react-query';
-// import { fetchTownInfo } from '../../apis/memberApi';
-// import { fetchJobRequests, allowJobRequest } from '../../apis/townApi';
-// import AdminLayout from './AdminLayout';
-// import { AdminTable, AdminModal } from '../../components';
-// import { ContentWrapper, Title } from './styled';
-
-// const AdminJobRequest = () => {
-//   const { data: townInfo = {} } = useQuery('townInfo', fetchTownInfo);
-//   const { data: jobrequests = [], refetch } = useQuery(
-//     'jobrequests',
-//     fetchJobRequests
-//   );
-
-//   const [isModalOpen, setIsModalOpen] = useState(false);
-//   const [selectedJobRequestId, setSelectedJobRequestId] = useState(null);
-
-//   const headers = ['No', '역할', '코멘트', '신청인', '승인 여부'];
-//   const tableData = jobrequests.map((jobrequest, index) => ({
-//     no: { type: 'text', value: index + 1 },
-//     name: { type: 'text', value: jobrequest.name },
-//     comments: { type: 'text', value: jobrequest.comments },
-//     nickName: { type: 'text', value: jobrequest.nickName },
-//     allowYN: {
-//       type: jobrequest.allowYN === 'Y' ? 'text' : 'button',
-//       value: jobrequest.allowYN === 'Y' ? '승인 완료' : '승인',
-//       onClick: () => {
-//         setSelectedJobRequestId(jobrequest.jobRequestId);
-//         setIsModalOpen(true);
-//       },
-//     },
-//   }));
-
-//   const mutation = useMutation(allowJobRequest, {
-//     onSuccess: () => {
-//       refetch();
-//       setIsModalOpen(false);
-//     },
-//     onError: (error) => {
-//       console.error('승인 실패:', error);
-//     },
-//   });
-
-//   const handleConfirm = () => {
-//     if (selectedJobRequestId) {
-//       mutation.mutate(selectedJobRequestId);
-//     }
-//   };
-
-//   const handleCancel = () => {
-//     setIsModalOpen(false);
-//   };
-
-//   return (
-//     <AdminLayout townInfo={townInfo}>
-//       <ContentWrapper>
-//         <Title>역할 신청 내역</Title>
-//         <AdminTable
-//           headers={headers}
-//           data={tableData}
-//           emptyMessage='역할 신청 내역이 없습니다.'
-//         />
-//       </ContentWrapper>
-//       {isModalOpen && (
-//         <AdminModal
-//           isOpen={isModalOpen}
-//           onConfirm={handleConfirm}
-//           onCancel={handleCancel}
-//           title='승인하시겠습니까?'
-//         />
-//       )}
-//     </AdminLayout>
-//   );
-// };
-
-// export default AdminJobRequest;
-
 import React, { useState } from 'react';
 import { useQuery, useMutation } from 'react-query';
 import { fetchJobRequests, allowJobRequest } from '../../apis/townApi';
 import AdminLayout from '../../layouts/AdminLayout';
 import { AdminTable, AdminModal } from '../../components';
 import { ContentWrapper, Title } from './styled';
+
+/**
+ * 관리자 역할 신청 내역 페이지
+ * @author 임원정
+ * @since 2024.09.03
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.03 	임원정        최초 생성
+ * </pre>
+ */
 
 const AdminJobRequest = () => {
   const { data: jobrequests = [], refetch } = useQuery(

--- a/src/pages/AdminJobRequest/index.jsx
+++ b/src/pages/AdminJobRequest/index.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useQuery, useMutation } from 'react-query';
 import { fetchJobRequests, allowJobRequest } from '../../apis/townApi';
 import AdminLayout from '../../layouts/AdminLayout';
-import { AdminTable, AdminModal } from '../../components';
+import { AdminTable, AdminModal, Loading } from '../../components';
 import { ContentWrapper, Title } from './styled';
 
 /**
@@ -19,17 +19,23 @@ import { ContentWrapper, Title } from './styled';
  */
 
 const AdminJobRequest = () => {
-  const { data: jobrequests = [], refetch } = useQuery(
-    'jobrequests',
-    fetchJobRequests
+  const [page, setPage] = useState(1);
+  const [size, setSize] = useState(10);
+
+  const { data, isLoading, refetch } = useQuery(
+    ['jobRequests', page, size],
+    () => fetchJobRequests(page, size)
   );
+
+  const jobrequests = data?.content || [];
+  const totalPages = data?.totalPages || 1; // 전체 페이지 수
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedJobRequestId, setSelectedJobRequestId] = useState(null);
 
   const headers = ['No', '역할', '코멘트', '신청인', '승인 여부'];
   const tableData = jobrequests.map((jobrequest, index) => ({
-    no: { type: 'text', value: index + 1 },
+    no: { type: 'text', value: (page - 1) * size + index + 1 },
     name: { type: 'text', value: jobrequest.name },
     comments: { type: 'text', value: jobrequest.comments },
     nickName: { type: 'text', value: jobrequest.nickName },
@@ -67,11 +73,18 @@ const AdminJobRequest = () => {
     <AdminLayout>
       <ContentWrapper>
         <Title>역할 신청 내역</Title>
-        <AdminTable
-          headers={headers}
-          data={tableData}
-          emptyMessage='역할 신청 내역이 없습니다.'
-        />
+        {isLoading ? (
+          <Loading text='로딩 중...' />
+        ) : (
+          <AdminTable
+            headers={headers}
+            data={tableData}
+            emptyMessage='역할 신청 내역이 없습니다.'
+            currentPage={page}
+            totalPages={totalPages}
+            onPageChange={(newPage) => setPage(newPage)}
+          />
+        )}
       </ContentWrapper>
       {isModalOpen && (
         <AdminModal

--- a/src/pages/AdminJobRequest/styled.js
+++ b/src/pages/AdminJobRequest/styled.js
@@ -1,26 +1,4 @@
 import styled from 'styled-components';
-import { colors } from '../../styles/colors';
-
-// export const Container = styled.div`
-//   width: 100vw;
-//   height: 100vh;
-//   background: ${colors.background_gray};
-//   display: flex;
-//   flex-direction: column;
-//   align-items: center;
-//   justify-content: flex-start;
-//   padding: 3vh 4vw 4vh;
-//   box-sizing: border-box;
-// `;
-
-// export const Wrapper = styled.div`
-//   width: 100%;
-//   height: 100%;
-//   display: flex;
-//   align-items: center;
-//   justify-content: space-between;
-//   padding-top: 2vw;
-// `;
 
 export const ContentWrapper = styled.div`
   width: 80%;

--- a/src/pages/AdminMain/index.jsx
+++ b/src/pages/AdminMain/index.jsx
@@ -1,50 +1,3 @@
-// import React from 'react';
-// import { useQuery } from 'react-query';
-// import { fetchTownInfo } from '../../apis/memberApi';
-// import {
-//   AdminHeader,
-//   AdminNav,
-//   TownTaxStatus,
-//   JobStatus,
-//   WishStatus,
-//   QuestStatus,
-// } from '../../components';
-// import { Container, ContentWrapper, Wrapper } from './styled';
-
-// /**
-//  * 관리자 메인 페이지
-//  * @author 임원정
-//  * @since 2024.09.03
-//  * @version 1.0
-//  *
-//  * <pre>
-//  * 수정일        수정자        수정내용
-//  * ----------  --------    ---------------------------
-//  * 2024.09.03 	임원정        최초 생성
-//  * </pre>
-//  */
-
-// const AdminMain = () => {
-//   const { data: townInfo = {} } = useQuery('townInfo', fetchTownInfo);
-
-//   return (
-//     <Container>
-//       <AdminHeader />
-//       <Wrapper>
-//         <AdminNav townInfo={townInfo} />
-//         <ContentWrapper>
-//           <TownTaxStatus townInfo={townInfo} />
-//           <JobStatus />
-//           <WishStatus />
-//           <QuestStatus />
-//         </ContentWrapper>
-//       </Wrapper>
-//     </Container>
-//   );
-// };
-
-// export default AdminMain;
-
 import React from 'react';
 import {
   TownTaxStatus,
@@ -54,6 +7,19 @@ import {
 } from '../../components';
 import AdminLayout from '../../layouts/AdminLayout';
 import { ContentWrapper } from './styled';
+
+/**
+ * 관리자 메인 페이지
+ * @author 임원정
+ * @since 2024.09.03
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.03 	임원정        최초 생성
+ * </pre>
+ */
 
 const AdminMain = () => {
   return (

--- a/src/pages/AdminMain/styled.js
+++ b/src/pages/AdminMain/styled.js
@@ -1,26 +1,4 @@
 import styled from 'styled-components';
-import { colors } from '../../styles/colors';
-
-// export const Container = styled.div`
-//   width: 100vw;
-//   height: 100vh;
-//   background: ${colors.background_gray};
-//   display: flex;
-//   flex-direction: column;
-//   align-items: center;
-//   justify-content: flex-start;
-//   padding: 3vh 4vw 4vh;
-//   box-sizing: border-box;
-// `;
-
-// export const Wrapper = styled.div`
-//   width: 100%;
-//   height: 100%;
-//   display: flex;
-//   align-items: center;
-//   justify-content: space-between;
-//   padding-top: 2vw;
-// `;
 
 export const ContentWrapper = styled.div`
   width: 80%;

--- a/src/pages/Closet/index.jsx
+++ b/src/pages/Closet/index.jsx
@@ -16,6 +16,7 @@ import {
 } from '../../components';
 import back from '../../assets/images/back.svg';
 import heendy from '../../assets/images/heendy_body.png';
+import face1 from '../../assets/images/heendy_face1.png';
 import { updateProfile } from '../../apis/closetApi';
 import html2canvas from 'html2canvas';
 
@@ -69,8 +70,6 @@ const Closet = () => {
         setClothes([...clothes, itemData]);
         setSelectedItems((prev) => [...prev, itemData.id]);
       }
-
-      console.log(selectedItems);
     }
   };
 
@@ -86,6 +85,9 @@ const Closet = () => {
     setIsModalOpen(false);
     updateProfile(profileImage)
       .then((response) => {
+        setSelectedItems([]);
+        setSelectedType(0);
+        setSelectedFace(face1);
         navigate('/closet-entry');
       })
       .catch((error) => {


### PR DESCRIPTION
###  작업한 내용
- 관리자 역할 페이지 레이아웃 사용하도록 주석 제거
- 요청 조회 관련 API 페이지네이션 적용할 수 있도록 수정
- 관리자 메인 페이지에서 4개만 보여주고 각 현황 더보기 버튼 클릭 시 페이지 넘어가도록 수정
- 흰디 옷장 페이지 다시 접속 시 선택했던 옷들 유지되는 거 프로필 업로드 시 reset하도록 수정
![image](https://github.com/user-attachments/assets/e5009747-4bda-4b19-9c79-fb60a9f03fef)
![image](https://github.com/user-attachments/assets/8d93b2f0-3e0f-4849-b246-a0b1632b332a)
