### PR TITLE
feat: dept 페이지에 구글 애널리틱스 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18.3.1",
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.3.1",
+        "react-ga4": "^2.1.0",
         "react-query": "^3.39.3",
         "react-router-dom": "^6.26.1",
         "react-scripts": "5.0.1",
@@ -17000,6 +17001,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
+      "license": "MIT"
+    },
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==",
       "license": "MIT"
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^18.3.1",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.3.1",
+    "react-ga4": "^2.1.0",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.26.1",
     "react-scripts": "5.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,28 @@
 import { RecoilRoot } from 'recoil';
+import React, { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import Router from './Router';
+import ReactGA from 'react-ga4';
 
 import './styles/reset.css';
 
 const queryClient = new QueryClient();
+const GA_TRACKING_ID = process.env.REACT_APP_GA_TRACKING_ID;
 
+// function App() {
+//   return (
+//     <RecoilRoot>
+//       <QueryClientProvider client={queryClient}>
+//         <Router />
+//       </QueryClientProvider>
+//     </RecoilRoot>
+//   );
+// }
 function App() {
+  useEffect(() => {
+    ReactGA.initialize(GA_TRACKING_ID);
+  }, []);
+
   return (
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>

--- a/src/App.js
+++ b/src/App.js
@@ -9,15 +9,6 @@ import './styles/reset.css';
 const queryClient = new QueryClient();
 const GA_TRACKING_ID = process.env.REACT_APP_GA_TRACKING_ID;
 
-// function App() {
-//   return (
-//     <RecoilRoot>
-//       <QueryClientProvider client={queryClient}>
-//         <Router />
-//       </QueryClientProvider>
-//     </RecoilRoot>
-//   );
-// }
 function App() {
   useEffect(() => {
     ReactGA.initialize(GA_TRACKING_ID);

--- a/src/pages/Dept/index.jsx
+++ b/src/pages/Dept/index.jsx
@@ -144,24 +144,6 @@ const Dept = () => {
     setIsWishSelected(true);
   };
 
-  // const handlePurchaseClick = () => {
-  //   if (selectedItem) {
-  //     setIsPurchaseModalOpen(true);
-  //   } else {
-  //     setPurchaseMessage('구매할 아이템이 선택되지 않았습니다.');
-  //     setIsResultModalOpen(true);
-  //   }
-  // };
-
-  // const confirmPurchase = () => {
-  //   if (selectedItem) {
-  //     purchaseMutation.mutate({
-  //       itemId: selectedItem.clothId || selectedItem.wishId,
-  //       isWish: isWishSelected,
-  //     });
-  //     setIsPurchaseModalOpen(false);
-  //   }
-  // };
   const handlePurchaseClick = () => {
     if (selectedItem) {
       // 구매를 시도한 상품 정보 전송

--- a/src/pages/Dept/index.jsx
+++ b/src/pages/Dept/index.jsx
@@ -1,5 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { useInfiniteQuery, useMutation, useQuery } from 'react-query';
+import ReactGA from 'react-ga4';
+
 import {
   Header,
   Button,
@@ -142,8 +144,41 @@ const Dept = () => {
     setIsWishSelected(true);
   };
 
+  // const handlePurchaseClick = () => {
+  //   if (selectedItem) {
+  //     setIsPurchaseModalOpen(true);
+  //   } else {
+  //     setPurchaseMessage('구매할 아이템이 선택되지 않았습니다.');
+  //     setIsResultModalOpen(true);
+  //   }
+  // };
+
+  // const confirmPurchase = () => {
+  //   if (selectedItem) {
+  //     purchaseMutation.mutate({
+  //       itemId: selectedItem.clothId || selectedItem.wishId,
+  //       isWish: isWishSelected,
+  //     });
+  //     setIsPurchaseModalOpen(false);
+  //   }
+  // };
   const handlePurchaseClick = () => {
     if (selectedItem) {
+      // 구매를 시도한 상품 정보 전송
+      ReactGA.event({
+        items: [
+          {
+            id: selectedItem.clothId || selectedItem.wishId,
+            name: selectedItem.name,
+            category: 'Cloth', // 카테고리 명 변경 가능
+            action: 'Product Viewed',
+            brand: selectedItem.brand,
+            price: selectedItem.price,
+            quantity: 1,
+          },
+        ],
+      });
+
       setIsPurchaseModalOpen(true);
     } else {
       setPurchaseMessage('구매할 아이템이 선택되지 않았습니다.');
@@ -153,6 +188,18 @@ const Dept = () => {
 
   const confirmPurchase = () => {
     if (selectedItem) {
+      // 실제 구매 이벤트 전송
+      ReactGA.event({
+        category: 'Cloth',
+        action: 'Purchase',
+        name: selectedItem.name,
+        brand: selectedItem.brand,
+        quantity: 1,
+        price: selectedItem.price,
+        transaction_id: selectedItem.clothId || selectedItem.wishId,
+      });
+
+      // 구매 처리
       purchaseMutation.mutate({
         itemId: selectedItem.clothId || selectedItem.wishId,
         isWish: isWishSelected,


### PR DESCRIPTION
###  작업한 내용
- 구글 애널리틱스 추가
- app.js에서 구글 애널리틱스 고유 ID를 이용한 초기화 해주기
- dept 페이지에서 클릭이벤트발생 시 데이터를 애널리틱스에 보내주기
- 1. 상품 클릭 후 구매 버튼 클릭 시 데이터전송(모달오픈)
- 2. 1 다음 모달에서 구매버튼을 클릭 시(실제 구매) 데이터 전송
- .env파일에 구글 애널리틱스 고유 ID 설정
