### PR TITLE
design: 투자페이지 스크롤 막기

### DIFF
--- a/src/pages/Invest/styled.js
+++ b/src/pages/Invest/styled.js
@@ -11,6 +11,7 @@ export const Container = styled.div`
   height: 92dvh;
   padding: 4dvh 8dvw;
   gap: 3dvh;
+  overflow-y: hidden;
 `;
 
 export const Title = styled.div`


### PR DESCRIPTION
###  작업한 내용
- 투자페이지 스크롤 방지 위한 overflow-y 추가
<img width="291" alt="스크린샷 2024-09-15 오전 11 46 20" src="https://github.com/user-attachments/assets/a49d0763-0a36-4420-82c0-3593c847b721">
